### PR TITLE
Django 1.6, media_root, csrf_exempt

### DIFF
--- a/commerceml/conf.py
+++ b/commerceml/conf.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -
 import os
+from django.conf import settings
 
 RESPONSE_SUCCESS = 'success'
 RESPONSE_PROGRESS = 'progress'
@@ -17,5 +18,4 @@ Property = 'path.to.property'
 MAX_EXEC_TIME = 60
 USE_ZIP = False
 FILE_LIMIT = 0
-FILE_ROOT = os.path.join('files', 'cml')
-
+FILE_ROOT = os.path.join(settings.MEDIA_ROOT, 'cml')

--- a/commerceml/conf.py
+++ b/commerceml/conf.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -
 import os
-from django.conf import settings
 
 RESPONSE_SUCCESS = 'success'
 RESPONSE_PROGRESS = 'progress'
@@ -18,4 +17,4 @@ Property = 'path.to.property'
 MAX_EXEC_TIME = 60
 USE_ZIP = False
 FILE_LIMIT = 0
-FILE_ROOT = os.path.join(settings.MEDIA_ROOT, 'cml')
+FILE_ROOT = os.path.join('files', 'cml')

--- a/commerceml/contrib/django/urls.py
+++ b/commerceml/contrib/django/urls.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import patterns, url
+except ImportError:
+    from django.conf.urls.defaults import patterns, url
 
-urlpatterns = patterns("commerceml.contrib.django.views",
+urlpatterns = patterns('commerceml.contrib.django.views',
     url(r'^1c_exchange.php$', 'dispatcher', name='cml-dispatcher')
 )

--- a/commerceml/contrib/django/views.py
+++ b/commerceml/contrib/django/views.py
@@ -10,6 +10,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.http import HttpResponse
 
 from django.contrib.auth.decorators import permission_required
+from django.views.decorators.csrf import csrf_exempt
 
 from commerceml.conf import RESPONSE_SUCCESS, RESPONSE_ERROR
 
@@ -25,6 +26,7 @@ from commerceml.contrib.django.signals import (requested_catalog_file,
 logger = logging.getLogger(__name__)
 
 
+@csrf_exempt
 @http_auth
 @permission_required('cml.exchange_1c')
 def dispatcher(request):


### PR DESCRIPTION
Добавлена поддержка Django 1.6,
Добавлен csrf_exempt для dispatcher view,
FILE_ROOT - теперь папка cml в media_root.
